### PR TITLE
feat: 컴포넌트 생성과 초기화 함수 연결

### DIFF
--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -152,8 +152,9 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="src\ECS\CameraSystem.h" />
-    <ClInclude Include="src\Engine\Shader.h" />
+    <ClInclude Include="src\ECS\ComponentSystem.h" />
     <ClInclude Include="src\ECS\Components.h" />
+    <ClInclude Include="src\ECS\System.h" />
     <ClInclude Include="src\ECS\entt.hpp" />
     <ClInclude Include="src\Engine\DX11App.h" />
     <ClInclude Include="src\Engine\DataTypes.h" />
@@ -164,21 +165,22 @@
     <ClInclude Include="src\Engine\FbxOutData.h" />
     <ClInclude Include="src\Engine\Log.h" />
     <ClInclude Include="src\Engine\Scene.h" />
+    <ClInclude Include="src\Engine\Shader.h" />
+    <ClInclude Include="src\Engine\TimeMgr.h" />
     <ClInclude Include="src\Engine\common.h" />
     <ClInclude Include="src\Engine_include.h" />
-    <ClInclude Include="src\ECS\System.h" />
-    <ClInclude Include="src\Engine\TimeMgr.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\ECS\CameraSystem.cpp" />
-    <ClCompile Include="src\Engine\Shader.cpp" />
+    <ClCompile Include="src\ECS\ComponentSystem.cpp" />
+    <ClCompile Include="src\ECS\System.cpp" />
     <ClCompile Include="src\Engine\DX11App.cpp" />
     <ClCompile Include="src\Engine\Engine.cpp" />
     <ClCompile Include="src\Engine\FbxLoader.cpp" />
     <ClCompile Include="src\Engine\FbxOutData.cpp" />
     <ClCompile Include="src\Engine\Log.cpp" />
     <ClCompile Include="src\Engine\Scene.cpp" />
-    <ClCompile Include="src\ECS\System.cpp" />
+    <ClCompile Include="src\Engine\Shader.cpp" />
     <ClCompile Include="src\Engine\TimeMgr.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -12,6 +12,18 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\ECS\CameraSystem.h">
+      <Filter>src\ECS</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ECS\ComponentSystem.h">
+      <Filter>src\ECS</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ECS\Components.h">
+      <Filter>src\ECS</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ECS\System.h">
+      <Filter>src\ECS</Filter>
+    </ClInclude>
     <ClInclude Include="src\ECS\entt.hpp">
       <Filter>src\ECS</Filter>
     </ClInclude>
@@ -42,19 +54,29 @@
     <ClInclude Include="src\Engine\Scene.h">
       <Filter>src\Engine</Filter>
     </ClInclude>
+    <ClInclude Include="src\Engine\Shader.h">
+      <Filter>src\Engine</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Engine\TimeMgr.h">
+      <Filter>src\Engine</Filter>
+    </ClInclude>
     <ClInclude Include="src\Engine\common.h">
       <Filter>src\Engine</Filter>
     </ClInclude>
     <ClInclude Include="src\Engine_include.h">
       <Filter>src</Filter>
     </ClInclude>
-    <ClInclude Include="src\ECS\Components.h" />
-    <ClInclude Include="src\Engine\Shader.h" />
-    <ClInclude Include="src\ECS\System.h" />
-    <ClInclude Include="src\ECS\CameraSystem.h" />
-    <ClInclude Include="src\Engine\TimeMgr.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\ECS\CameraSystem.cpp">
+      <Filter>src\ECS</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ECS\ComponentSystem.cpp">
+      <Filter>src\ECS</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ECS\System.cpp">
+      <Filter>src\ECS</Filter>
+    </ClCompile>
     <ClCompile Include="src\Engine\DX11App.cpp">
       <Filter>src\Engine</Filter>
     </ClCompile>
@@ -73,10 +95,12 @@
     <ClCompile Include="src\Engine\Scene.cpp">
       <Filter>src\Engine</Filter>
     </ClCompile>
-    <ClCompile Include="src\Engine\Shader.cpp" />
-    <ClCompile Include="src\ECS\System.cpp" />
-    <ClCompile Include="src\ECS\CameraSystem.cpp" />
-    <ClCompile Include="src\Engine\TimeMgr.cpp" />
+    <ClCompile Include="src\Engine\Shader.cpp">
+      <Filter>src\Engine</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Engine\TimeMgr.cpp">
+      <Filter>src\Engine</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\premake5.lua" />

--- a/Engine/src/ECS/CameraSystem.cpp
+++ b/Engine/src/ECS/CameraSystem.cpp
@@ -49,8 +49,8 @@ void CameraSystem::OnUpdate(entt::registry& reg)
 	for (auto ent : view_trans)
 	{
 		auto& trans = view_trans.get<Transform>(ent);
-		trans.view_matrix = view_matrix;
-		trans.projection_matrix = projection_matrix;
+		trans.view_matrix_ = view_matrix;
+		trans.projection_matrix_ = projection_matrix;
 	}
 }
 

--- a/Engine/src/ECS/Components.h
+++ b/Engine/src/ECS/Components.h
@@ -8,28 +8,102 @@ namespace KGCA41B
 	struct Component
 	{
 		string tag;
+		virtual void OnConstruct() {};
+		virtual void OnDestroy() {};
+		virtual void OnUpdate() {};
 	};
 
 	struct Transform : public Component
 	{
-		XMMATRIX world_matrix;
-		XMMATRIX view_matrix;
-		XMMATRIX projection_matrix;
+		XMMATRIX world_matrix_;
+		XMMATRIX view_matrix_;
+		XMMATRIX projection_matrix_;
 
-		CbTransform cb_transform;
-		ComPtr<ID3D11Buffer> cb_buffer;
+		CbTransform cb_transform_;
+		ComPtr<ID3D11Buffer> cb_buffer_;
+
+		virtual void OnConstruct() override {
+
+			this->world_matrix_ = this->cb_transform_.world_matrix = XMMatrixIdentity();
+			this->world_matrix_ = this->cb_transform_.world_matrix = XMMatrixIdentity();
+			this->world_matrix_ = this->cb_transform_.world_matrix = XMMatrixIdentity();
+
+			D3D11_BUFFER_DESC buffer_desc;
+			D3D11_SUBRESOURCE_DATA subresource_data;
+
+			ZeroMemory(&buffer_desc, sizeof(buffer_desc));
+			ZeroMemory(&subresource_data, sizeof(subresource_data));
+
+			buffer_desc.ByteWidth = sizeof(CbTransform);
+			buffer_desc.Usage = D3D11_USAGE_DEFAULT;
+			buffer_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+
+
+			subresource_data.pSysMem = &this->cb_transform_;
+			if (FAILED(DX11App::GetInst()->GetDevice()->CreateBuffer(&buffer_desc, &subresource_data, &this->cb_buffer_)))
+			{
+				MessageBox(nullptr, L"상수 버퍼 생성 실패", L"오류", 0);
+				assert(nullptr);
+			}
+		}
 	};
 
-	struct StaticMesh : public Component
+	struct StaticMesh : public Transform
 	{
-		vector<SingleMesh> mesh_list;
-		VsDefault vs_default;
+		vector<SingleMesh> mesh_list_;
+		VsDefault vs_default_;
+
+		virtual void OnConstruct() override {
+
+			for (auto& single_mesh : this->mesh_list_)
+			{
+				D3D11_BUFFER_DESC vertex_buffer_desc;
+				D3D11_SUBRESOURCE_DATA vertex_buffer_data;
+
+				ZeroMemory(&vertex_buffer_desc, sizeof(vertex_buffer_desc));
+				ZeroMemory(&vertex_buffer_data, sizeof(vertex_buffer_data));
+
+				vertex_buffer_desc.ByteWidth = sizeof(Vertex) * single_mesh.vertices.size();
+				vertex_buffer_desc.Usage = D3D11_USAGE_DEFAULT;
+				vertex_buffer_desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+				vertex_buffer_data.pSysMem = single_mesh.vertices.data();
+
+				if (FAILED(DX11App::GetInst()->GetDevice()->CreateBuffer(&vertex_buffer_desc, &vertex_buffer_data, &single_mesh.vertex_buffer)))
+				{
+					MessageBox(nullptr, L"버텍스 버퍼 생성 실패", L"오류", 0);
+					assert(nullptr);
+				}
+			}
+		}
 	};
 
 	struct SkeletalMesh : public Component
 	{
-		vector<SingleMesh> mesh_list;
-		VsSkinned vs_skinned;
+		map<UINT, XMMATRIX> bindposes_;
+		CbSkeleton bone_data_;
+		ComPtr<ID3D11Buffer> bone_buffer_;
+
+		virtual void OnConstruct() override {
+			for (int i = 0; i < 255; ++i)
+				this->bone_data_.mat_skeleton[i] = XMMatrixIdentity();
+
+			D3D11_BUFFER_DESC bufferDesc;
+			D3D11_SUBRESOURCE_DATA subresourceData;
+
+			ZeroMemory(&bufferDesc, sizeof(bufferDesc));
+			ZeroMemory(&subresourceData, sizeof(subresourceData));
+
+			bufferDesc.ByteWidth = sizeof(CbSkeleton);
+			bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+			bufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+			subresourceData.pSysMem = this->bone_buffer_.GetAddressOf();
+
+			if (FAILED(DX11App::GetInst()->GetDevice()->CreateBuffer(&bufferDesc, &subresourceData, this->bone_buffer_.GetAddressOf())))
+			{
+				MessageBox(nullptr, L"스켈레톤 상수 버퍼 생성 실패", L"오류", 0);
+				assert(nullptr);
+			}
+		}
 	};
 
 	struct Material : public Component


### PR DESCRIPTION
- 부모 컴포넌트가 OnConstruct 함수를 가상함수로 가지도록 구현
- 자식 컴포넌트들은 부모 클래스의 OnConstruct 함수 재정의하여 서로다른 초기화가 이루어질 수 있도록 함
- registry의 on_construct에 연결하여 컴포넌트 생성시마다 동적 바인딩으로 각각의 컴포넌트의 초기화 함수에 연결될 수 있도록 함