### PR TITLE
fix: Fbx임포트 수정 및 인덱스버퍼로 렌더링

### DIFF
--- a/Engine/src/ECS/RenderSystem.cpp
+++ b/Engine/src/ECS/RenderSystem.cpp
@@ -140,10 +140,13 @@ void RenderSystem::RenderStaticMesh(StaticMesh& static_mesh)
 		UINT stride = sizeof(Vertex);
 		UINT offset = 0;
 
+		device_context->IASetVertexBuffers(0, 1, single_mesh.vertex_buffer.GetAddressOf(), &stride, &offset);
+		device_context->IASetIndexBuffer(single_mesh.index_buffer.Get(), DXGI_FORMAT_R32_UINT, 0);
+
 		device_context->IASetInputLayout(shader->InputLayoyt());
 		device_context->VSSetShader(shader->Get(), 0, 0);
-		device_context->IASetVertexBuffers(0, 1, single_mesh.vertex_buffer.GetAddressOf(), &stride, &offset);
-		device_context->Draw(single_mesh.vertices.size(), 0);
+
+		device_context->DrawIndexed(single_mesh.indices.size(), 0, 0);
 	}
 }
 
@@ -157,8 +160,11 @@ void RenderSystem::RenderSkeletalMesh(SkeletalMesh& skeletal_mesh)
 		UINT stride = sizeof(SkinnedVertex);
 		UINT offset = 0;
 		device_context->IASetVertexBuffers(0, 1, single_mesh.vertex_buffer.GetAddressOf(), &stride, &offset);
+		device_context->IASetIndexBuffer(single_mesh.index_buffer.Get(), DXGI_FORMAT_R32_UINT, 0);
+		
 		device_context->IASetInputLayout(shader->InputLayoyt());
 		device_context->VSSetShader(shader->Get(), 0, 0);
-		device_context->Draw(single_mesh.vertices.size(), 0);
+
+		device_context->DrawIndexed(single_mesh.indices.size(), 0, 0);
 	}
 }

--- a/Engine/src/Engine/DataTypes.h
+++ b/Engine/src/Engine/DataTypes.h
@@ -37,6 +37,8 @@ namespace KGCA41B
 	{
 		vector<VertexType> vertices;
 		ComPtr<ID3D11Buffer> vertex_buffer;
+		vector<UINT> indices;
+		ComPtr<ID3D11Buffer> index_buffer;
 	};
 
 	struct CbTransform

--- a/Engine/src/Engine/SingletonClass/ResourceMgr.cpp
+++ b/Engine/src/Engine/SingletonClass/ResourceMgr.cpp
@@ -28,9 +28,10 @@ bool ResourceMgr::ImportFbx(string filename)
     for (auto out_mesh : fbx_loader.out_mesh_list)
     {
         if (out_mesh->is_skinned)
-        {
+        { 
             SingleMesh<SkinnedVertex> single_mesh;
             single_mesh.vertices = out_mesh->skinned_vertices;
+            single_mesh.indices = out_mesh->indices;
             res_skeletal_mesh.push_back(single_mesh);
             res_skeleton.merge(out_mesh->bind_poses);
         }
@@ -38,6 +39,7 @@ bool ResourceMgr::ImportFbx(string filename)
         {
             SingleMesh<Vertex> single_mesh;
             single_mesh.vertices = out_mesh->vertices;
+            single_mesh.indices = out_mesh->indices;
             res_static_mesh.push_back(single_mesh);
         }
     }
@@ -51,13 +53,12 @@ bool ResourceMgr::ImportFbx(string filename)
 
     for (auto& single_mesh : res_static_mesh)
     {
-        CreateVertexBuffers(single_mesh);
+        CreateBuffers(single_mesh);
     }
     for (auto& single_mesh : res_skeletal_mesh)
     {
-        CreateVertexBuffers(single_mesh);
+        CreateBuffers(single_mesh);
     }
-
 
 
     if (res_static_mesh.size() > 0)
@@ -76,10 +77,13 @@ bool ResourceMgr::ImportFbx(string filename)
     return true;
 }
 
-bool ResourceMgr::CreateVertexBuffers(SingleMesh<Vertex>& mesh)
+bool ResourceMgr::CreateBuffers(SingleMesh<Vertex>& mesh)
 {
     D3D11_BUFFER_DESC desc;
     D3D11_SUBRESOURCE_DATA subdata;
+    HRESULT hr;
+
+    // CreateVertexBuffer
 
     ZeroMemory(&desc, sizeof(desc));
     ZeroMemory(&subdata, sizeof(subdata));
@@ -89,17 +93,34 @@ bool ResourceMgr::CreateVertexBuffers(SingleMesh<Vertex>& mesh)
     desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
     subdata.pSysMem = mesh.vertices.data();
 
-    HRESULT hr = DX11APP->GetDevice()->CreateBuffer(&desc, &subdata, mesh.vertex_buffer.GetAddressOf());
+    hr = DX11APP->GetDevice()->CreateBuffer(&desc, &subdata, mesh.vertex_buffer.GetAddressOf());
+    if (FAILED(hr))
+        return false;
+
+    // CreateIndexBuffer
+
+    ZeroMemory(&desc, sizeof(desc));
+    ZeroMemory(&subdata, sizeof(subdata));
+
+    desc.ByteWidth = sizeof(UINT) * mesh.indices.size();
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+    subdata.pSysMem = mesh.indices.data();
+
+    hr = DX11APP->GetDevice()->CreateBuffer(&desc, &subdata, mesh.index_buffer.GetAddressOf());
     if (FAILED(hr))
         return false;
 
     return true;
 }
 
-bool ResourceMgr::CreateVertexBuffers(SingleMesh<SkinnedVertex>& mesh)
+bool ResourceMgr::CreateBuffers(SingleMesh<SkinnedVertex>& mesh)
 {
     D3D11_BUFFER_DESC desc;
     D3D11_SUBRESOURCE_DATA subdata;
+    HRESULT hr;
+
+    // CreateVertexBuffer
 
     ZeroMemory(&desc, sizeof(desc));
     ZeroMemory(&subdata, sizeof(subdata));
@@ -109,7 +130,21 @@ bool ResourceMgr::CreateVertexBuffers(SingleMesh<SkinnedVertex>& mesh)
     desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
     subdata.pSysMem = mesh.vertices.data();
 
-    HRESULT hr = DX11APP->GetDevice()->CreateBuffer(&desc, &subdata, mesh.vertex_buffer.GetAddressOf());
+    hr = DX11APP->GetDevice()->CreateBuffer(&desc, &subdata, mesh.vertex_buffer.GetAddressOf());
+    if (FAILED(hr))
+        return false;
+
+    // CreateIndexBuffer
+
+    ZeroMemory(&desc, sizeof(desc));
+    ZeroMemory(&subdata, sizeof(subdata));
+
+    desc.ByteWidth = sizeof(UINT) * mesh.indices.size();
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+    subdata.pSysMem = mesh.indices.data();
+
+    hr = DX11APP->GetDevice()->CreateBuffer(&desc, &subdata, mesh.index_buffer.GetAddressOf());
     if (FAILED(hr))
         return false;
 

--- a/Engine/src/Engine/SingletonClass/ResourceMgr.h
+++ b/Engine/src/Engine/SingletonClass/ResourceMgr.h
@@ -37,8 +37,8 @@ namespace KGCA41B
 
 		bool ImportFbx(string filename);
 
-		bool CreateVertexBuffers(SingleMesh<Vertex>& mesh);
-		bool CreateVertexBuffers(SingleMesh<SkinnedVertex>& mesh);
+		bool CreateBuffers(SingleMesh<Vertex>& mesh);
+		bool CreateBuffers(SingleMesh<SkinnedVertex>& mesh);
 
 		bool ImportVsDefault(string filename);
 		bool ImportVsSkinned(string filename);

--- a/Engine/src/Engine/common.h
+++ b/Engine/src/Engine/common.h
@@ -12,6 +12,8 @@
 #include <locale>
 #include <codecvt>
 #include <functional>
+#include <set>
+#include <algorithm>
 using namespace std;
 using namespace Microsoft::WRL;
 using namespace DirectX;

--- a/TestGame/HLSL/SkinningPS.hlsl
+++ b/TestGame/HLSL/SkinningPS.hlsl
@@ -22,6 +22,7 @@ SamplerState g_SampleWrap		: register(s0);
 float4 PS(PS_OUT input) : SV_Target
 {
 	//float4 vColor = g_txTex.Sample(g_SampleWrap , input.t);
+
 	float fDot = max(0.3f, dot(input.n, -input.vLight) * 100);
 	return float4(fDot, fDot, fDot, 1) * input.c;// *vColor;
 }

--- a/TestGame/HLSL/SkinningVS.hlsl
+++ b/TestGame/HLSL/SkinningVS.hlsl
@@ -55,7 +55,7 @@ VS_OUT VS(VS_IN input)
 	output.c = input.c;
 	output.t = input.t;
 
-	output.vLight = float3(0, -1, 0);
+	output.vLight = float3(0, 0, -1);
 
 	return output;
 }

--- a/TestGame/TestGame.vcxproj
+++ b/TestGame/TestGame.vcxproj
@@ -155,6 +155,28 @@
     <ClCompile Include="src\main.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <FxCompile Include="HLSL\BasicShapePS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+      <ShaderModel>5.0</ShaderModel>
+      <EntryPointName>PS</EntryPointName>
+    </FxCompile>
+    <FxCompile Include="HLSL\BasicShapeVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+      <ShaderModel>5.0</ShaderModel>
+      <EntryPointName>VS</EntryPointName>
+    </FxCompile>
+    <FxCompile Include="HLSL\SkinningPS.hlsl">
+      <ShaderType>Pixel</ShaderType>
+      <ShaderModel>5.0</ShaderModel>
+      <EntryPointName>PS</EntryPointName>
+    </FxCompile>
+    <FxCompile Include="HLSL\SkinningVS.hlsl">
+      <ShaderType>Vertex</ShaderType>
+      <ShaderModel>5.0</ShaderModel>
+      <EntryPointName>VS</EntryPointName>
+    </FxCompile>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Engine\Engine.vcxproj">
       <Project>{DBC7D3B0-C769-FE86-B024-12DB9C6585D7}</Project>
     </ProjectReference>

--- a/TestGame/TestGame.vcxproj.filters
+++ b/TestGame/TestGame.vcxproj.filters
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Shader">
-      <UniqueIdentifier>{FC0C0CD1-E8AE-36A7-D169-4AFBBDAABDF7}</UniqueIdentifier>
+    <Filter Include="HLSL">
+      <UniqueIdentifier>{18D9857C-0410-870D-ADFC-6C109912030F}</UniqueIdentifier>
     </Filter>
     <Filter Include="src">
       <UniqueIdentifier>{2DAB880B-99B4-887C-2230-9F7C8E38947C}</UniqueIdentifier>
@@ -23,16 +23,16 @@
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="HLSL\BasicShapePS.hlsl">
-      <Filter>Shader</Filter>
+      <Filter>HLSL</Filter>
     </FxCompile>
     <FxCompile Include="HLSL\BasicShapeVS.hlsl">
-      <Filter>Shader</Filter>
+      <Filter>HLSL</Filter>
     </FxCompile>
     <FxCompile Include="HLSL\SkinningPS.hlsl">
-      <Filter>Shader</Filter>
+      <Filter>HLSL</Filter>
     </FxCompile>
     <FxCompile Include="HLSL\SkinningVS.hlsl">
-      <Filter>Shader</Filter>
+      <Filter>HLSL</Filter>
     </FxCompile>
   </ItemGroup>
 </Project>

--- a/premake5.lua
+++ b/premake5.lua
@@ -96,7 +96,7 @@ project "TestGame"
 	{
 		"%{prj.name}/src/**.h",
 		"%{prj.name}/src/**.cpp",
-		"%{prj.name}/Shader/**.hlsl"
+		"%{prj.name}/HLSL/**.hlsl"
 	} 
 
 	includedirs


### PR DESCRIPTION
FBX에서 정점을 추출하는 로직을 수정했습니다. 이제는 메쉬를 이루는 정점들이 중복되지 않으며 인덱스 버퍼로 렌더링 합니다. 따라서 렌더 시스템에서 꼭 DrawIndexed()로 그려야 합니다.