### PR TITLE
Feature/physics

### DIFF
--- a/Engine/src/ECS/CameraSystem.h
+++ b/Engine/src/ECS/CameraSystem.h
@@ -21,6 +21,10 @@ namespace KGCA41B
 	private:
 		Camera* camera;
 		D3D11_VIEWPORT* viewport;
+
+		XMMATRIX view_matrix;
+		XMMATRIX projection_matrix;
+
 		CbViewProj cb_viewproj;
 
 	public:

--- a/Engine/src/Engine/DataTypes.h
+++ b/Engine/src/Engine/DataTypes.h
@@ -160,3 +160,16 @@ static void XMtoRP(XMVECTOR& xmv, reactphysics3d::Vector2& rpv)
 	rpv.x = xmv.m128_f32[0];
 	rpv.y = xmv.m128_f32[1];
 }
+
+static void RPtoXM(reactphysics3d::Vector3& rpv, XMVECTOR& xmv)
+{
+	xmv.m128_f32[0] = rpv.x;
+	xmv.m128_f32[1] = rpv.y;
+	xmv.m128_f32[2] = rpv.z;
+}
+
+static void RPtoXM(reactphysics3d::Vector2& rpv, XMVECTOR& xmv)
+{
+	xmv.m128_f32[0] = rpv.x;
+	xmv.m128_f32[1] = rpv.y;
+}

--- a/Engine/src/Engine/Level.h
+++ b/Engine/src/Engine/Level.h
@@ -1,10 +1,6 @@
 #pragma once
 #include "DataTypes.h"
 #include "DllMacro.h"
-#include "Shader.h"
-#include "Texture.h"
-
-#include <variant>
 #include "Components.h"
 
 
@@ -18,15 +14,19 @@ namespace KGCA41B
 
 	public:
 		bool CreateLevel(UINT num_row, UINT num_col, float cell_distance, float uv_scale);
+		bool CreateHeightField(float min_height, float max_height);
 
 		void Update();
 		void Render();
+		XMVECTOR LevelPicking(MouseRay* mouse_ray);
 
 	private:
 		void GenVertexNormal();
+		void GetHeightList();
+
 		XMFLOAT3 GetNormal(UINT i0, UINT i1, UINT i2);
 		bool CreateBuffers();
-
+		
 	public:
 		string vs_id_;
 		string ps_id_;
@@ -45,6 +45,11 @@ namespace KGCA41B
 		float uv_scale_;
 		float max_height_;
 		vector<float> height_list_;
+
+	private:
+		reactphysics3d::HeightFieldShape* height_field_shape_;
+		reactphysics3d::Collider* height_field_collider_;
+		reactphysics3d::CollisionBody* height_field_body_;
 
 	private:
 		ID3D11Device* device_;

--- a/Engine/src/Engine/SingletonClass/InputMgr.h
+++ b/Engine/src/Engine/SingletonClass/InputMgr.h
@@ -2,7 +2,7 @@
 #include "common.h"
 #include "DllMacro.h"
 #include <dinput.h>
-
+  
 namespace KGCA41B
 {
 	enum

--- a/Engine/src/Engine/SingletonClass/PhysicsMgr.cpp
+++ b/Engine/src/Engine/SingletonClass/PhysicsMgr.cpp
@@ -48,11 +48,8 @@ Vector3 PhysicsMgr::RaycastMouse(MouseRay* mouse_ray)
 	Ray new_ray(mouse_ray->start_point, mouse_ray->end_point);
 
 	MouseRayCallback ray_callback;
-	RaycastInfo raycast_info;
 
 	physics_world_->raycast(new_ray, &ray_callback);
 
-	decimal result = ray_callback.notifyRaycastHit(raycast_info);
-
-	return raycast_info.worldPoint;
+	return ray_callback.hitpoint;
 }

--- a/Engine/src/Engine/SingletonClass/PhysicsMgr.h
+++ b/Engine/src/Engine/SingletonClass/PhysicsMgr.h
@@ -12,9 +12,12 @@ namespace KGCA41B
 
         virtual decimal notifyRaycastHit(const RaycastInfo& info)
         {
-            // Return a fraction of 1.0 to gather all hits 
-            return decimal(1.0);
+            hitpoint = info.worldPoint;
+
+            return decimal(0.0);
         }
+
+        Vector3 hitpoint;
     };
 
     class DLL_API PhysicsMgr
@@ -28,10 +31,12 @@ namespace KGCA41B
 
     public:
         Vector3 RaycastMouse(MouseRay* mouse_ray);
+        PhysicsWorld* GetPhysicsWorld() { return physics_world_; }
 
+    public:
+        PhysicsCommon physics_common_;
 
     private:
-        PhysicsCommon physics_common_;
         PhysicsWorld* physics_world_;
         float accmulator = 0.0f;
     };


### PR DESCRIPTION
### Raycast를 활용한 마우스 레벨 피킹 
- 마우스 위치를 3D 공간 좌표로 변환하여, 레이를 생성하는 로직은 카메라 시스템에서 구현하였습니다.  
- 레벨의 평면을 콜라이더로 만들고 피직스월드에 할당하여, 3D 공간상에서 레이캐스팅을 수행하고 레이 충돌 시 히트포인트를 반환하는 로직을 Level 클래스에서 구현하였습니다.