### PR TITLE
Feature/physics

### DIFF
--- a/Engine/src/ECS/CameraSystem.h
+++ b/Engine/src/ECS/CameraSystem.h
@@ -15,6 +15,7 @@ namespace KGCA41B
 
 		MouseRay CreateMouseRay();
 		Camera* GetCamera();
+		XMFLOAT2 ndc;
 	private:
 		void CameraMovement(InputMapping& input_mapping);
 		void CameraAction(InputMapping& input_mapping);
@@ -24,6 +25,7 @@ namespace KGCA41B
 		Camera* camera;
 		D3D11_VIEWPORT* viewport;
 
+		XMMATRIX world_matrix;
 		XMMATRIX view_matrix;
 		XMMATRIX projection_matrix;
 

--- a/Engine/src/Engine/Level.cpp
+++ b/Engine/src/Engine/Level.cpp
@@ -86,8 +86,8 @@ bool Level::CreateHeightField(float min_height, float max_height)
 	GetHeightList();
 
 	height_field_shape_ = PHYSICS->physics_common_.createHeightFieldShape(
-		num_col_vertex_ * cell_distance_,
-		num_row_vertex_ * cell_distance_,
+		num_col_vertex_,// * cell_distance_,
+		num_row_vertex_,// * cell_distance_,
 		min_height,
 		max_height,
 		height_list_.data(),
@@ -95,6 +95,8 @@ bool Level::CreateHeightField(float min_height, float max_height)
 
 	if (height_field_shape_ == nullptr)
 		return false;
+
+	height_field_shape_->setScale(Vector3(10, 1, 10));
 
 	reactphysics3d::Transform transform = reactphysics3d::Transform::identity();
 	height_field_body_ = PHYSICS->GetPhysicsWorld()->createCollisionBody(transform);
@@ -154,7 +156,7 @@ void Level::Render()
 	device_context_->DrawIndexed(level_mesh_.indices.size(), 0, 0);
 }
 
-void Level::LevelPicking(const MouseRay& mouse_ray, float circle_radius, XMFLOAT4 circle_color)
+XMVECTOR Level::LevelPicking(const MouseRay& mouse_ray, float circle_radius, XMFLOAT4 circle_color)
 {
 	Ray ray(mouse_ray.start_point, mouse_ray.end_point);
 	MouseRayCallback ray_callback;
@@ -172,6 +174,8 @@ void Level::LevelPicking(const MouseRay& mouse_ray, float circle_radius, XMFLOAT
 		hit_circle_.data.is_hit = false;
 		hit_circle_.data.circle_color = {1, 1, 1, 1};
 	}
+
+	return hit_circle_.data.hitpoint;
 }
 
 void Level::GenVertexNormal()
@@ -237,15 +241,20 @@ float Level::GetHeightAt(float x, float z)
 
 void Level::GetHeightList()
 {
-	int num_row = static_cast<int>(num_row_vertex_) * cell_distance_;
-	int num_col = static_cast<int>(num_col_vertex_) * cell_distance_;
+	//int num_row = static_cast<int>(num_row_vertex_) * cell_distance_;
+	//int num_col = static_cast<int>(num_col_vertex_) * cell_distance_;
 
-	for (int r = -(num_row / 2); r < num_row / 2; ++r)
+	//for (int r = -(num_row / 2); r < num_row / 2; ++r)
+	//{
+	//	for (int c = -(num_col / 2); c < num_col / 2; ++c)
+	//	{
+	//		height_list_.push_back(GetHeightAt(r, c));
+	//	}
+	//}
+
+	for (auto vertex : level_mesh_.vertices)
 	{
-		for (int c = -(num_col / 2); c < num_col / 2; ++c)
-		{
-			height_list_.push_back(GetHeightAt(r, c));
-		}
+		height_list_.push_back(vertex.p.y);
 	}
 }
 

--- a/Engine/src/Engine/Level.h
+++ b/Engine/src/Engine/Level.h
@@ -33,7 +33,7 @@ namespace KGCA41B
 
 		void Update();
 		void Render();
-		void LevelPicking(const MouseRay& mouse_ray, float circle_radius, XMFLOAT4 circle_color);
+		XMVECTOR LevelPicking(const MouseRay& mouse_ray, float circle_radius, XMFLOAT4 circle_color);
 
 	private:
 		void GenVertexNormal();

--- a/Engine/src/Engine/SingletonClass/DX11App.cpp
+++ b/Engine/src/Engine/SingletonClass/DX11App.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "DX11App.h"
 
+
 bool DX11App::OnInit(POINT buffer_size, HWND hwnd)
 {
     HRESULT hr;

--- a/Engine/src/Engine/SingletonClass/Engine.cpp
+++ b/Engine/src/Engine/SingletonClass/Engine.cpp
@@ -40,14 +40,14 @@ LRESULT CALLBACK WindowProc(
 }
 
 namespace KGCA41B {
-	bool Engine::OnInit(HINSTANCE hinstance, LPCWSTR title, POINT wnd_size)
+	bool Engine::OnInit(HINSTANCE hinstance, LPCWSTR title, POINT screen_size)
 	{
 		// 윈도우 초기화
-		if (InitWindow(hinstance, title, wnd_size) == false)
+		if (InitWindow(hinstance, title, screen_size) == false)
 			return false;
 
 		// DX 초기화
-		if (DX11APP->OnInit(wnd_size, hwnd) == false)
+		if (DX11APP->OnInit(screen_size, hwnd) == false)
 			return false;
 
 		GUI->Init(ENGINE->GetWindowHandle(), DX11APP->GetDevice(), DX11APP->GetDeviceContext());
@@ -109,11 +109,16 @@ namespace KGCA41B {
 		DX11APP->OnRelease();
 	}
 
-	bool Engine::InitWindow(HINSTANCE hinstance, LPCWSTR title, POINT wnd_size)
+	bool Engine::InitWindow(HINSTANCE hinstance, LPCWSTR title, POINT screen_size)
 	{
 		this->hinstance = hinstance;
 		this->title = title;
-		this->wnd_size = wnd_size;
+
+
+		RECT rc = { 0, 0, screen_size.x, screen_size.y };
+		AdjustWindowRect(&rc, WS_OVERLAPPEDWINDOW, false);
+		this->wnd_size.x = rc.right - rc.left;
+		this->wnd_size.y = rc.bottom - rc.top;
 
 		WNDCLASS window_class;
 		ZeroMemory(&window_class, sizeof(window_class));
@@ -145,10 +150,7 @@ namespace KGCA41B {
 		ShowWindow(hwnd, SW_SHOW);
 		UpdateWindow(hwnd);
 
-		RECT rc;
-		GetClientRect(hwnd, &rc);
-		wnd_size.x = rc.right - rc.left;
-		wnd_size.y = rc.bottom - rc.top;
+
 
 		return true;
 	}

--- a/Engine/src/Engine/SingletonClass/Engine.h
+++ b/Engine/src/Engine/SingletonClass/Engine.h
@@ -8,7 +8,7 @@ namespace KGCA41B {
 #define ENGINE KGCA41B::Engine::GetInst()
 
 	public:
-		bool OnInit(HINSTANCE hinstance, LPCWSTR title, POINT wnd_size);
+		bool OnInit(HINSTANCE hinstance, LPCWSTR title, POINT screen_size);
 		void Run(Scene* scene);
 		void OnResized();
 		void OnRelease();
@@ -19,7 +19,7 @@ namespace KGCA41B {
 		HWND      GetWindowHandle() { return hwnd; }
 
 	private:
-		bool InitWindow(HINSTANCE hinstance, LPCWSTR title, POINT wnd_size);
+		bool InitWindow(HINSTANCE hinstance, LPCWSTR title, POINT screen_size);
 
 	private:
 		HINSTANCE hinstance;

--- a/Engine/src/Engine/SingletonClass/PhysicsMgr.cpp
+++ b/Engine/src/Engine/SingletonClass/PhysicsMgr.cpp
@@ -22,7 +22,7 @@ bool PhysicsMgr::Init()
 
 	// Change the number of iterations of the position solver 
 	physics_world_->setNbIterationsPositionSolver(5);
-	
+
 
 	return true;
 }


### PR DESCRIPTION
### 마우스 레이 피킹 오류 수정
- 기존에 마우스의 위치와 충돌지점의 오차가 있었으나 레이 길이를 잔뜩 늘리는 방법으로 해결했습니다. (레이 길이 약 10만)이유는 정확히 모르겠으나 일단 마우스와 거의 일치하는 부분에서 충돌이 일어난다는 점은 호재일듯 합니다.