### PR TITLE
test : 정점 버퍼에 대한 Map() Unmap() 테스트

### DIFF
--- a/Engine/src/Engine/Level.cpp
+++ b/Engine/src/Engine/Level.cpp
@@ -162,18 +162,17 @@ void Level::Render()
 	if (edit_mode)
 	{
 		D3D11_MAPPED_SUBRESOURCE mapped_resource = {};
-		device_context_->Map(level_mesh_.vertex_buffer.Get(), 0, D3D11_MAP_READ, 0, &mapped_resource);
+		HRESULT hr = device_context_->Map(level_mesh_.vertex_buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped_resource);
 
-		const Vertex* mapped_vertices = reinterpret_cast<const Vertex *>(mapped_resource.pData);
-		size_t mapped_size = mapped_resource.RowPitch / sizeof(Vertex);
+		XMFLOAT3* mapped_vertices = reinterpret_cast<XMFLOAT3*>(mapped_resource.pData);
+		size_t mapped_size = mapped_resource.RowPitch / sizeof(XMFLOAT3);
 
 		for (int i = 0; i < mapped_size; ++i)
 		{
-			level_mesh_.vertices[i] = mapped_vertices[i];
-		}
+			mapped_vertices[i];
 
+		}
 		device_context_->Unmap(level_mesh_.vertex_buffer.Get(), 0);
-		device_context_->UpdateSubresource(level_mesh_.vertex_buffer.Get(), 0, nullptr, level_mesh_.vertices.data(), 0, 0);
 	}
 }
 
@@ -302,8 +301,8 @@ bool Level::CreateBuffers()
 	ZeroMemory(&subdata, sizeof(subdata));
 
 	desc.ByteWidth = sizeof(Vertex) * level_mesh_.vertices.size();
-	desc.Usage = D3D11_USAGE_STAGING;
-	desc.BindFlags = 0;
+	desc.Usage = D3D11_USAGE_DYNAMIC;
+	desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
 	desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 	subdata.pSysMem = level_mesh_.vertices.data();
 


### PR DESCRIPTION
### 정점 버퍼에 대한 Map() Unmap()으로 일단은 정점 버퍼를 GPU로부터 가져오고 값을 변경하는 것은 확인했습니다. 그러나 이것을 매 프레임 호출하는 것은 큰 비용이 생기기 때문에, 레벨 편집에 있어 호출은 최소한으로 해야 할 것입니다.

### HLSL에 대한 새로운 지식을 위키에 추가하였습니다.