### PR TITLE
Movement 컴포넌트 구현

### DIFF
--- a/Engine/src/ECS/Components.h
+++ b/Engine/src/ECS/Components.h
@@ -19,6 +19,19 @@ namespace KGCA41B
 		virtual void OnUpdate() {};
 	};
 
+	struct C_Movement : public Component
+	{
+		entt::entity actor_id;
+
+		XMVECTOR direction;
+		float speed;
+		float max_speed;
+		float acceleration;
+		float gravity_scale;
+		float rotation;
+		float angular_velocity;
+	};
+
 	struct C_Transform : public Component
 	{
 		XMMATRIX local;

--- a/Engine/src/ECS/Components.h
+++ b/Engine/src/ECS/Components.h
@@ -19,19 +19,6 @@ namespace KGCA41B
 		virtual void OnUpdate() {};
 	};
 
-	struct C_Movement : public Component
-	{
-		entt::entity actor_id;
-
-		XMVECTOR direction;
-		float speed;
-		float max_speed;
-		float acceleration;
-		float gravity_scale;
-		float rotation;
-		float angular_velocity;
-	};
-
 	struct C_Transform : public Component
 	{
 		XMMATRIX local;
@@ -237,6 +224,22 @@ namespace KGCA41B
 				child->OnUpdate(registry, entity, world * cur_transform->local);
 			}
 		}
+
+		void ApplyMovement(entt::registry& registry, entt::entity entity, XMMATRIX world = XMMatrixIdentity()) {
+			C_Transform* cur_transform = static_cast<C_Transform*>(registry.storage(id_type)->get(entity));
+			cur_transform->world = world;
+			cur_transform->OnUpdate();
+
+			
+			XMVECTOR local_scale, local_rotation, local_translation;
+			XMMatrixDecompose(&local_scale, &local_rotation, &local_translation, cur_transform->local);
+			
+			XMMATRIX translation_matrix = XMMatrixTranslationFromVector(local_translation);
+			
+			for (auto child : children) {
+				child->ApplyMovement(registry, entity, world * translation_matrix);
+			}
+		}
 	};
 
 	struct TransformTree
@@ -270,6 +273,22 @@ namespace KGCA41B
 		}
 	};
 
+	struct C_Movement : public Component
+	{
+		TransformTree* actor_transform_tree;
+
+		XMVECTOR direction = { 0.0f, 0.0f, 0.0f, 0.0f };
+		float speed = 0.0f;
+		float max_speed = 0.0f;
+		float acceleration = 0.0f;
+		float gravity_scale = 0.0f;
+		float rotation = 0.0f;
+		float angular_velocity = 0.0f;
+
+		C_Movement(TransformTree* actor_transform_tree) :
+			actor_transform_tree(actor_transform_tree) {};
+
+	};
 
 	struct C_BoxShape : public C_Transform
 	{

--- a/Engine/src/ECS/MovementSystem.cpp
+++ b/Engine/src/ECS/MovementSystem.cpp
@@ -1,0 +1,21 @@
+#include "stdafx.h"
+#include "TimeMgr.h"
+#include "MovementSystem.h"
+
+void KGCA41B::MovementSystem::OnCreate(entt::registry& reg)
+{
+}
+
+void KGCA41B::MovementSystem::OnUpdate(entt::registry& reg)
+{
+	auto view_movement = reg.view<C_Movement>();
+
+	for (auto entity_id : view_movement)
+	{
+		auto* movement_component = reg.try_get<C_Movement>(entity_id);
+
+		XMMATRIX translation_matrix = XMMatrixTranslationFromVector(movement_component->direction * movement_component->speed * TM_DELTATIME);
+
+		movement_component->actor_transform_tree->root_node->ApplyMovement(reg, entity_id, translation_matrix);
+	}
+}

--- a/Engine/src/ECS/MovementSystem.h
+++ b/Engine/src/ECS/MovementSystem.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "System.h"
+
+namespace KGCA41B
+{
+	class DLL_API MovementSystem : public System
+	{
+	public:
+		MovementSystem() = default;
+		~MovementSystem() = default;
+
+		virtual void OnCreate(entt::registry& reg) override;
+		virtual void OnUpdate(entt::registry& reg) override;
+
+		XMFLOAT2 ndc;
+	private:
+
+
+	private:
+
+	};
+}

--- a/Engine/src/Engine/Character.cpp
+++ b/Engine/src/Engine/Character.cpp
@@ -1,0 +1,11 @@
+#include "stdafx.h"
+#include "Character.h"
+
+void KGCA41B::Character::CharacterInit(entt::registry& registry, AABBShape collision_box)
+{
+	entity_id_ = registry.create();
+	registry.emplace_or_replace<C_Movement>(entity_id_, &transform_tree_);
+	movement_component_ = registry.try_get<C_Movement>(entity_id_);
+
+	OnInit(registry, collision_box);
+}

--- a/Engine/src/Engine/Character.h
+++ b/Engine/src/Engine/Character.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Actor.h"
+
+namespace KGCA41B
+{
+	class DLL_API Character : Actor
+	{
+	protected:
+		C_Movement*	 movement_component_;
+	public:
+		void		 CharacterInit(entt::registry& registry, AABBShape collision_box);
+	};
+}

--- a/Engine/src/Engine_include.h
+++ b/Engine/src/Engine_include.h
@@ -16,11 +16,13 @@
 #include "ECS/SoundSystem.h"
 #include "ECS/LightingSystem.h"
 #include "ECS/EffectSystem.h"
+#include "ECS/MovementSystem.h"
 
 #include "Engine/Scene.h"
 #include "Engine/FbxLoader.h"
 #include "Engine/StaticObject.h"
 #include "Engine/Actor.h"
+#include "Engine/Character.h"
 #include "Engine/Level.h"
 #include "Engine/Log.h"
 #include "Engine/EntryPoint.h"


### PR DESCRIPTION
- 기존의 트랜스폼 트리의 업데이트 로직과 달리 Movement 시스템에서는 Translation 정보만을 전파하여 하위 컴포넌트의 움직임 방향이 달라지는 문제 방지