### PR TITLE
Scene 매니저 구현

### DIFF
--- a/Engine/src/Engine/Scene.h
+++ b/Engine/src/Engine/Scene.h
@@ -1,8 +1,10 @@
 #pragma once
+#include "entt.hpp"
 #include "stdafx.h"
 #include "DllMacro.h"
 #include "TimeMgr.h"
 #include "InputMgr.h"
+#include "Actor.h"
 
 namespace reality {
 	class DLL_API Scene
@@ -15,5 +17,7 @@ namespace reality {
 		virtual void OnUpdate() = 0;
 		virtual void OnRender() = 0;
 		virtual void OnRelease() = 0;
+	protected:
+		entt::registry reg_scene_;
 	};
 }

--- a/Engine/src/Engine/SingletonClass/Engine.cpp
+++ b/Engine/src/Engine/SingletonClass/Engine.cpp
@@ -4,6 +4,7 @@
 #include "GUIMgr.h"
 #include "PhysicsMgr.h"
 #include "EventMgr.h"
+#include "SceneMgr.h"
 
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
@@ -58,10 +59,8 @@ namespace reality {
 		return true;
 	}
 
-	void Engine::Run(Scene* scene)
+	void Engine::Run()
 	{
-		scene->OnInit();
-
 		bool done = false;
 		while (!done)
 		{
@@ -81,18 +80,17 @@ namespace reality {
 			DINPUT->Update();
 			PHYSICS->Update();
 
-			scene->OnUpdate();
+			SCENE_MGR->OnUpdate();
 
 			EVENT->ProcessEvents();
 
 			// Render Here
 			DX11APP->PreRender(true, true, true);
 
-			scene->OnRender();
+			SCENE_MGR->OnRender();
 
 			DX11APP->PostRender(false);
 		}
-		scene->OnRelease();
 	}
 
 	void Engine::OnResized()

--- a/Engine/src/Engine/SingletonClass/Engine.h
+++ b/Engine/src/Engine/SingletonClass/Engine.h
@@ -1,5 +1,4 @@
 #include "DX11App.h"
-#include "Scene.h"
 
 namespace reality {
 	class DLL_API Engine
@@ -9,7 +8,7 @@ namespace reality {
 
 	public:
 		bool OnInit(HINSTANCE hinstance, LPCWSTR title, POINT screen_size);
-		void Run(Scene* scene);
+		void Run();
 		void OnResized();
 		void OnRelease();
 

--- a/Engine/src/Engine/SingletonClass/SceneMgr.cpp
+++ b/Engine/src/Engine/SingletonClass/SceneMgr.cpp
@@ -1,0 +1,30 @@
+#include "stdafx.h"
+#include "SceneMgr.h"
+
+void reality::SceneMgr::OnInit()
+{
+	if (cur_scene.get() != nullptr) {
+		cur_scene->OnInit();
+	}
+}
+
+void reality::SceneMgr::OnUpdate()
+{
+	if (cur_scene.get() != nullptr) {
+		cur_scene->OnUpdate();
+	}
+}
+
+void reality::SceneMgr::OnRender()
+{
+	if (cur_scene.get() != nullptr) {
+		cur_scene->OnRender();
+	}
+}
+
+void reality::SceneMgr::OnRelease()
+{
+	if (cur_scene.get() != nullptr) {
+		cur_scene->OnRelease();
+	}
+}

--- a/Engine/src/Engine/SingletonClass/SceneMgr.h
+++ b/Engine/src/Engine/SingletonClass/SceneMgr.h
@@ -14,6 +14,10 @@ namespace reality {
             cur_scene->OnInit();
         }
 
+        weak_ptr<Scene> GetCurScene() {
+            return weak_ptr<Scene>(cur_scene);
+        }
+
         virtual void OnInit();
         virtual void OnUpdate();
         virtual void OnRender();

--- a/Engine/src/Engine/SingletonClass/SceneMgr.h
+++ b/Engine/src/Engine/SingletonClass/SceneMgr.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "stdafx.h"
+#include "Scene.h"
+
+namespace reality {
+    class DLL_API SceneMgr {
+        SINGLETON(SceneMgr)
+#define SCENE_MGR SceneMgr::GetInst()
+    public:
+        template <typename SceneClass>
+        void SetScene() {
+            cur_scene = make_shared<SceneClass>();
+            cur_scene->OnInit();
+        }
+
+        virtual void OnInit();
+        virtual void OnUpdate();
+        virtual void OnRender();
+        virtual void OnRelease();
+    private:
+        shared_ptr<Scene> cur_scene;
+    };
+}

--- a/Engine/src/Engine_include.h
+++ b/Engine/src/Engine_include.h
@@ -6,6 +6,7 @@
 #include "Engine/SingletonClass/FbxMgr.h"
 #include "Engine/SingletonClass/FmodMgr.h"
 #include "Engine/SingletonClass/GUIMgr.h"
+#include "Engine/SingletonClass/SceneMgr.h"
 #include "Engine/SingletonClass/PhysicsMgr.h"
 #include "Engine/SingletonClass/EventMgr.h"
 #include "Engine/SingletonClass/InputEventMgr.h"

--- a/TestGame/src/TestGame.cpp
+++ b/TestGame/src/TestGame.cpp
@@ -5,19 +5,18 @@ void TestGame::OnInit()
 {
 	reality::RESOURCE->Init("../../Contents/");
 	reality::FMOD_MGR->Init();
-	sys_sound.OnCreate(reg_scene); 
+	sys_sound.OnCreate(reg_scene_); 
   
-	reality::ComponentSystem::GetInst()->OnInit(reg_scene);
+	reality::ComponentSystem::GetInst()->OnInit(reg_scene_);
 
-	ent_player = reg_scene.create();
+	ent_player = reg_scene_.create();
 
 
-	sys_render.OnCreate(reg_scene);
-	sys_camera.OnCreate(reg_scene);
-	sys_camera.TargetTag(reg_scene, "Debug");
+	sys_render.OnCreate(reg_scene_);
+	sys_camera.OnCreate(reg_scene_);
+	sys_camera.TargetTag(reg_scene_, "Debug");
 
-	Level level;
-	level.CreateLevel(3, 8, 100, {8, 8});
+	level.CreateLevel(3, 100, 100, {8, 8});
 	QUADTREE->Init(&level);
 }
 
@@ -28,7 +27,7 @@ void TestGame::OnUpdate()
 
 void TestGame::OnRender()
 {
-	sys_render.OnUpdate(reg_scene);
+	sys_render.OnUpdate(reg_scene_);
 }
 
 void TestGame::OnRelease()

--- a/TestGame/src/TestGame.h
+++ b/TestGame/src/TestGame.h
@@ -12,7 +12,7 @@ public:
 	virtual void OnRelease();
 
 private:
-	entt::registry reg_scene;
+	Level level;
 
 	entt::entity ent_player;
 

--- a/TestGame/src/main.cpp
+++ b/TestGame/src/main.cpp
@@ -4,9 +4,8 @@ int WINAPI wWinMain(HINSTANCE hinstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLi
 {
 	ENGINE->OnInit(hinstance, L"Game-Engine", { 1920, 1080 });
 
-	TestGame test_game;
-
-	ENGINE->Run(&test_game);
+	SCENE_MGR->SetScene<TestGame>();
+	ENGINE->Run();
 
 	ENGINE->OnRelease();
 


### PR DESCRIPTION
- 씬 매니저는 현재 동작할 씬을 설정하고, 현재 씬에 대한 정보를 외부에 알리는 역할을 하는 싱글톤 클래스
- 이제 엔진은 씬을 게임에서 넘겨받아 동작하지 않고, 씬 매니저에 설정된 씬을 돌리게 됨
   => 따라서 Engine의 Run 함수 실행 전에 씬 매니저의 씬이 설정되어야 한다.