### PR TITLE
Physics collisions

### DIFF
--- a/Engine/src/ECS/Components.h
+++ b/Engine/src/ECS/Components.h
@@ -51,20 +51,14 @@ namespace reality
 	{
 		reality::CapsuleShape capsule;
 
-		void SetCapsuleData(XMVECTOR base, XMVECTOR tip, float radius) {
-			capsule.base = base;
-			capsule.tip = tip;
-			capsule.radius = radius;
-
-			local = XMMatrixTranslationFromVector(capsule.tip);
+		void SetCapsuleData(XMVECTOR offset, float height, float radius) {
+			capsule = reality::CapsuleShape(offset, height, radius);
+			local = XMMatrixTranslationFromVector(capsule.base);
+			world = world * local;
 		}
 		virtual void OnUpdate() override
 		{
-			XMMATRIX translation = XMMatrixTranslationFromVector(world.r[3]);
-			world = translation;
-
-			capsule.base = XMVector3TransformCoord(capsule.base, translation);
-			capsule.tip = XMVector3TransformCoord(capsule.tip, translation);
+			capsule.base = world.r[3];
 		}
 	};
 
@@ -92,7 +86,7 @@ namespace reality
 		void SetLocalFrom(C_CapsuleCollision& capsule_collision, float arm_length)
 		{
 			local = XMMatrixTranslationFromVector(XMVectorSet(0, 1, -1, 0) * arm_length);
-			target_height = capsule_collision.capsule.tip.m128_f32[1];
+			target_height = capsule_collision.capsule.GetTipBaseAB()[0].m128_f32[1];
 			pitch_yaw = { 0, 0};
 			near_z = 1.f;
 			far_z = 100000.f;
@@ -420,12 +414,5 @@ namespace reality
 	{
 		string effect_id;
 		Effect effect;
-	};
-
-	struct PhysicsCollision : public C_Transform
-	{
-		reactphysics3d::CollisionShape* shape = nullptr;
-		reactphysics3d::Collider* collider = nullptr;
-		reactphysics3d::CollisionBody* body = nullptr;
 	};
 }

--- a/Engine/src/ECS/Systems/CameraSystem.cpp
+++ b/Engine/src/ECS/Systems/CameraSystem.cpp
@@ -142,7 +142,7 @@ RayShape CameraSystem::CreateMouseRay()
 RayShape reality::CameraSystem::CreateFrontRay()
 {
 	XMVECTOR ray_origin = camera->camera_pos;
-	XMVECTOR ray_dir = XMVector3Normalize(look);
+	XMVECTOR ray_dir = XMVector3Normalize(camera->look);
 	return RayShape(ray_origin, ray_dir * camera->far_z);
 }
 

--- a/Engine/src/Engine/LightMeshLevel.h
+++ b/Engine/src/Engine/LightMeshLevel.h
@@ -28,11 +28,6 @@ namespace reality
 		shared_ptr<LightMesh> level_mesh;
 		shared_ptr<VertexShader> vertex_shader;
 		shared_ptr<GeometryShader> geometry_shader;
-
-		//reactphysics3d::TriangleMesh* shape_mesh = nullptr;
-		//reactphysics3d::ConcaveMeshShape* level_shape = nullptr;
-		//reactphysics3d::Collider* level_collider = nullptr;
-		//reactphysics3d::CollisionBody* level_body = nullptr;
 	};
 }
 

--- a/Engine/src/Engine/Shape.h
+++ b/Engine/src/Engine/Shape.h
@@ -158,48 +158,28 @@ namespace reality {
         CapsuleShape()
         {
             base = XMVectorZero();
-            tip = XMVectorZero();
+            height = 0.0f;
             radius = 0.0f;
         }
-        CapsuleShape(float _min, float _max, float _radius)
-        {
-            base = XMVectorSet(0, _min, 0, 0);
-            tip = XMVectorSet(0, _max, 0, 0);
-            radius = _radius;
-        }
-        CapsuleShape(const XMVECTOR& _base, const XMVECTOR& _tip, const float& _radius)
+        CapsuleShape(const XMVECTOR& _base, const float& _height, const float& _radius)
         {
             base = _base;
-            tip = _tip;
+            height = _height;
             radius = _radius;
         }
-        CapsuleShape(const AABBShape& _aabb)
+        array<XMVECTOR, 4> GetTipBaseAB()
         {
-            base = _aabb.center + XMVectorSet(0, XMVectorGetY(_aabb.min), 0, 0);
-            tip = _aabb.center + XMVectorSet(0, XMVectorGetY(_aabb.max), 0, 0);
-            XMVECTOR extend = _aabb.max - _aabb.min;
-            extend.m128_f32[1] = 0;
-            radius = XMVectorGetX(XMVector3Length(extend));
-        }
-        vector<XMVECTOR> GetAB()
-        {
+            XMVECTOR tip = base + XMVectorSet(0, height, 0, 0);
+
             XMVECTOR normal = XMVector3Normalize(tip - base);
             XMVECTOR lineend = normal * radius;
             XMVECTOR A = base + lineend;
             XMVECTOR B = tip - lineend;
 
-            return { A, B };
+            return { tip, base, A, B };
         }
-        XMVECTOR GetCenter()
-        {
-            float x = (XMVectorGetX(base) + XMVectorGetX(tip)) / 2;
-            float y = (XMVectorGetY(base) + XMVectorGetY(tip)) / 2;
-            float z = (XMVectorGetZ(base) + XMVectorGetZ(tip)) / 2;
-
-            return XMVectorSet(x, y, z, 0);
-        }
-
-        XMVECTOR base, tip;
+        XMVECTOR base;
+        float height;
         float radius;
     };
 

--- a/Engine/src/Engine/SingletonClass/QuadTreeMgr.h
+++ b/Engine/src/Engine/SingletonClass/QuadTreeMgr.h
@@ -40,34 +40,37 @@ namespace reality {
 		void Release();
 
 	public:
-		void UpdatePhysics(float time_step);
-		void NodeCulling(SpaceNode* node);
-		void NodeCasting(RayShape& ray, SpaceNode* node);
-		void ObjectCulling();
+		void UpdatePhysics();
 		RayCallback RaycastAdjustLevel(RayShape& ray, float max_distance);
 		RayCallback RaycastAdjustActor(RayShape& ray);
-		int GetVisibleLeafCount();
+
+		void RegisterDynamicCapsule(entt::entity ent);
+
+	public:
+		int calculating_triagnles;
+		int ray_casted_nodes;
+		set<UINT> including_nodes_num;
+		XMVECTOR player_capsule_pos;
 
 	private:
 		UINT max_depth;
 		UINT node_count = 0;
-
-		vector<SpaceNode*> total_nodes_;
-		vector<SpaceNode*> leaf_nodes_;
-		set<SpaceNode*> visible_leaves;
-		map<float, SpaceNode*> casted_nodes_;
+		float physics_timestep = 1.0f / 30.0f;
 
 		SpaceNode* root_node_ = nullptr;
+		vector<SpaceNode*> total_nodes_;
+		vector<SpaceNode*> leaf_nodes_;
+		map<float, SpaceNode*> casted_nodes_;
 
-
+		map<entt::entity, C_CapsuleCollision*> dynamic_capsule_list;
 
 	private:
-		void InsertAllLeaves(SpaceNode* node);
+		void NodeCasting(RayShape& ray, SpaceNode* node);
+		void ObjectQueryByCapsule(CapsuleShape& capsule, SpaceNode* node, vector<SpaceNode*>& node_list);
 		SpaceNode* BuildTree(UINT depth, float row1, float col1, float row2, float col2);
 		void SetStaticTriangles(SpaceNode* node);
 
 	public:
-		int									UpdateNodeObjectBelongs(int node_num, const AABBShape& object_area, entt::entity object_id);
 		std::vector<int>					FindCollisionSearchNode(int node_num);
 		std::unordered_set<entt::entity>	GetObjectListInNode(int node_num);
 

--- a/TestGame/src/Player.cpp
+++ b/TestGame/src/Player.cpp
@@ -19,11 +19,7 @@ void Player::OnInit(entt::registry& registry)
 	registry.emplace_or_replace<reality::C_SkeletalMesh>(entity_id_, skm);
 
 	reality::C_CapsuleCollision capsule;
-	capsule.capsule.base = { 0, 0, 0, 0 };
-	capsule.capsule.radius = 5;
-	capsule.capsule.tip = { 0, 50, 0, 0 };
-	capsule.local = XMMatrixIdentity();
-	capsule.world = XMMatrixIdentity();
+	capsule.SetCapsuleData(XMVectorZero(), 50, 5);
 	registry.emplace<reality::C_CapsuleCollision>(entity_id_, capsule);
 
 	C_Camera camera;

--- a/TestGame/src/TestGame.cpp
+++ b/TestGame/src/TestGame.cpp
@@ -3,7 +3,7 @@
 
 void TestGame::OnInit()
 {
-	GUI->AddWidget("test_window", &test_window_);
+	GUI->AddWidget("property", &gw_property_);
 
 	reality::RESOURCE->Init("../../Contents/");
 	reality::ComponentSystem::GetInst()->OnInit(reg_scene_);
@@ -13,7 +13,7 @@ void TestGame::OnInit()
 	sys_camera.SetSpeed(1000);
 	sys_light.OnCreate(reg_scene_);
 
-	SCENE_MGR->AddPlayer<Player>();
+	auto player_entity = SCENE_MGR->AddPlayer<Player>();
 	sys_camera.TargetTag(reg_scene_, "Player");
 
 	auto character_actor = SCENE_MGR->GetPlayer<Player>(0);
@@ -38,6 +38,14 @@ void TestGame::OnInit()
 
 	sky_sphere.CreateSphere();
 	level.Create("DeadPoly_FullLevel.ltmesh", "LevelVS.cso", "LevelGS.cso");
+	QUADTREE->Init(&level);
+	QUADTREE->RegisterDynamicCapsule(player_entity);
+
+	gw_property_.AddProperty<float>("FPS", &TIMER->fps);
+	gw_property_.AddProperty<int>("raycasted nodes", &QUADTREE->ray_casted_nodes);
+	gw_property_.AddProperty<set<UINT>>("including nodes", &QUADTREE->including_nodes_num);
+	gw_property_.AddProperty<XMVECTOR>("player pos", &QUADTREE->player_capsule_pos);
+	gw_property_.AddProperty<int>("calculating triagnles", &QUADTREE->calculating_triagnles);
 }
 
 void TestGame::OnUpdate()
@@ -46,6 +54,7 @@ void TestGame::OnUpdate()
 	sys_camera.OnUpdate(reg_scene_);
 	sys_light.OnUpdate(reg_scene_);
 	sys_movement.OnUpdate(reg_scene_);
+	QUADTREE->Frame(&sys_camera);
 }
 
 void TestGame::OnRender()
@@ -54,10 +63,13 @@ void TestGame::OnRender()
 	level.Update();
 	level.Render();
 	sys_render.OnUpdate(reg_scene_);
+
+	GUI->RenderWidgets();
 }
 
 void TestGame::OnRelease()
 {
+	QUADTREE->Release();
 	PHYSICS->Release();
 	reality::RESOURCE->Release();
 }

--- a/TestGame/src/TestGame.h
+++ b/TestGame/src/TestGame.h
@@ -27,6 +27,7 @@ private:
 
 private:
 	TestWidget	test_window_;
+	PropertyWidget gw_property_;
 	FX_Effect	effect_;
 	reality::WorldRayCallback callback;
 	void CreateEffectFromRay(XMVECTOR hitpoint);

--- a/TestGame/src/TestWidget.cpp
+++ b/TestGame/src/TestWidget.cpp
@@ -20,3 +20,58 @@ void reality::TestWidget::SetPickingVector(XMVECTOR picking)
 {
 	picking_ = picking;
 }
+
+void reality::PropertyWidget::Update()
+{
+	ImGui::SetCurrentContext(GUI->GetContext());
+	ImGui::DockSpaceOverViewport(ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
+}
+
+void reality::PropertyWidget::Render()
+{
+	ImGui::Begin("Property");
+
+	for (auto& [name, prop] : properties)
+	{
+		ImGui::Text(string("\n[" + name + "]\n").c_str());
+
+		if (prop.type == typeid(float).hash_code() || prop.type == typeid(double).hash_code())
+		{
+			float casted_val = *static_cast<float*>(prop.value);
+			ImGui::Text(to_string(casted_val).c_str());
+		}
+
+		if (prop.type == typeid(int).hash_code())
+		{
+			int casted_val = *static_cast<int*>(prop.value);
+			ImGui::Text(to_string(casted_val).c_str());
+		}
+
+		if (prop.type == typeid(set<UINT>).hash_code())
+		{
+			set<UINT> casted_val = *static_cast<set<UINT>*>(prop.value);
+			string items;
+			for (auto& v : casted_val)
+			{
+				items += to_string(v) + ", ";
+			}
+			ImGui::Text(items.c_str());
+		}
+
+		if (prop.type == typeid(XMVECTOR).hash_code())
+		{
+			XMVECTOR casted_val = *static_cast<XMVECTOR*>(prop.value);
+			string vector;
+			vector =
+				string("x : ") + to_string(casted_val.m128_f32[0]) + "\n" +
+				string("y : ") + to_string(casted_val.m128_f32[1]) + "\n" +
+				string("z : ") + to_string(casted_val.m128_f32[2]) + "\n" +
+				string("w : ") + to_string(casted_val.m128_f32[3]) + "\n";
+
+			ImGui::Text(vector.c_str());
+		}
+	}
+
+
+	ImGui::End();
+}

--- a/TestGame/src/TestWidget.h
+++ b/TestGame/src/TestWidget.h
@@ -4,6 +4,12 @@
 
 namespace reality
 {
+	struct Property
+	{
+		void* value = nullptr;
+		size_t type;
+	};
+
 	class TestWidget : public reality::GuiWidget
 	{
 	public:
@@ -13,6 +19,26 @@ namespace reality
 		virtual void Render() override;
 	public:
 		void SetPickingVector(XMVECTOR picking);
+	};
+
+	class PropertyWidget : public reality::GuiWidget
+	{
+	public:
+		virtual void Update() override;
+		virtual void Render() override;
+
+		template<typename T>
+		void AddProperty(string name, T* data)
+		{
+			Property prop;
+			prop.value = (void*)data;
+			prop.type = typeid(T).hash_code();
+
+			properties.insert(make_pair(name, prop));
+		}
+
+	private:
+		std::map<string, Property> properties;
 	};
 }
 


### PR DESCRIPTION
### 삼각형을 대폭 줄인 새로운 레벨 메쉬(구글드라이브에 업데이트)
### 캡슐의 이동에 따라 노드 쿼리 (최대 4개의 포함 리프노드만 찾음)
### 카메라 방향으로 레이 생성 및 교차 노드 쿼리(알고리즘 개선 필요)
### 캡슐의 베이스 지점과 삼각형의 교차 테스트 완료(바닥 고정, 중력 적용은 아직)